### PR TITLE
Export env variables

### DIFF
--- a/src/main/java/tech/dtech/athena/model/Account.java
+++ b/src/main/java/tech/dtech/athena/model/Account.java
@@ -31,6 +31,9 @@ public class Account implements UserDetails {
     @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     private List<Role> roles = new ArrayList<>();
 
+    public Account() {
+    }
+
     public Account(String name, String email, String password) {
         this.name = name;
         this.email = email;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,15 +1,15 @@
 # Spring Data
 spring.datasource.platform=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
-spring.datasource.url=jdbc:mysql://${db.server}:${db.port}/${db.name}
-spring.datasource.username=${db.username}
-spring.datasource.password=${db.password}
+spring.datasource.url=${ATHENA_DB_CONN_URL}
+spring.datasource.username=${ATHENA_DB_USERNAME}
+spring.datasource.password=${ATHENA_DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.initialization-mode=never
 
 # jwt
-athena.jwt.secret=${token.secret}
+athena.jwt.secret=${ATHENA_JWT_SECRET}
 athena.jwt.expiration_millis=86400000
 
 # cors
-athena.cors.origins=http://localhost:3000
+athena.cors.origins=${ATHENA_CORS_ALLOWED_ORIGINS}


### PR DESCRIPTION
### # What?
An error was fixed where the JPA would not be able to execute queries on account because it didn't have the default constructor.

Also, environment variables were exported to use the system ones. This way it will make it easier for deploy.
The new variables are: 
* ATHENA_DB_CONN_URL
* ATHENA_DB_USERNAME
* ATHENA_DB_PASSWORD
* ATHENA_JWT_SECRET
* ATHENA_CORS_ALLOWED_ORIGINS

### # How?
Basically a change of names for now.