### PR TITLE
New endpoint - Find document type by id

### DIFF
--- a/src/main/java/tech/dtech/athena/document/controller/DocumentController.java
+++ b/src/main/java/tech/dtech/athena/document/controller/DocumentController.java
@@ -34,6 +34,11 @@ public class DocumentController {
         return ResponseEntity.ok(DocumentTypeDTO.from(documentTypes));
     }
 
+    @GetMapping(path = "/types/{id}")
+    public ResponseEntity<DocumentTypeDTO> get(@PathVariable long id) {
+        return ResponseEntity.ok(new DocumentTypeDTO(documentTypeService.get(id)));
+    }
+
     @PostMapping(path = "/types")
     public ResponseEntity<DocumentTypeDTO> create(@RequestBody @Valid DocumentTypeForm form, UriComponentsBuilder uriBuilder) {
         DocumentType documentType = documentTypeService.createNew(form.transform());

--- a/src/main/java/tech/dtech/athena/document/model/DocumentTypeDTO.java
+++ b/src/main/java/tech/dtech/athena/document/model/DocumentTypeDTO.java
@@ -9,7 +9,7 @@ public class DocumentTypeDTO {
     private String name;
 
     public static List<DocumentTypeDTO> from(List<DocumentType> documentTypes) {
-        return documentTypes.stream().map(type -> new DocumentTypeDTO(type)).collect(Collectors.toList());
+        return documentTypes.stream().map(DocumentTypeDTO::new).collect(Collectors.toList());
     }
 
     public DocumentTypeDTO(DocumentType documentType) {

--- a/src/main/java/tech/dtech/athena/document/usecase/DocumentTypeService.java
+++ b/src/main/java/tech/dtech/athena/document/usecase/DocumentTypeService.java
@@ -8,6 +8,8 @@ public interface DocumentTypeService {
 
     List<DocumentType> getAll();
 
+    DocumentType get(long id);
+
     DocumentType createNew(DocumentType documentType);
 
     DocumentType update(long id, DocumentType documentType);

--- a/src/main/java/tech/dtech/athena/document/usecase/DocumentTypeServiceImpl.java
+++ b/src/main/java/tech/dtech/athena/document/usecase/DocumentTypeServiceImpl.java
@@ -24,6 +24,13 @@ public class DocumentTypeServiceImpl implements DocumentTypeService {
     }
 
     @Override
+    public DocumentType get(long id) {
+        return repository.findById(id).orElseThrow(() -> {
+            throw new ResourceNotFoundException(DocumentType.ENTITY_NAME);
+        });
+    }
+
+    @Override
     public DocumentType createNew(DocumentType documentType) {
         if (repository.findByName(documentType.getName()).isPresent()) {
             throw new DuplicatedRecordException(DocumentType.ENTITY_NAME, DocumentType.FIELD_NAME_NAME);

--- a/src/main/java/tech/dtech/athena/document/usecase/DocumentTypeServiceImpl.java
+++ b/src/main/java/tech/dtech/athena/document/usecase/DocumentTypeServiceImpl.java
@@ -25,9 +25,7 @@ public class DocumentTypeServiceImpl implements DocumentTypeService {
 
     @Override
     public DocumentType get(long id) {
-        return repository.findById(id).orElseThrow(() -> {
-            throw new ResourceNotFoundException(DocumentType.ENTITY_NAME);
-        });
+        return repository.findById(id).orElseThrow(() -> new ResourceNotFoundException(DocumentType.ENTITY_NAME));
     }
 
     @Override

--- a/src/test/java/tech/dtech/athena/document/controller/DocumentControllerTest.java
+++ b/src/test/java/tech/dtech/athena/document/controller/DocumentControllerTest.java
@@ -217,7 +217,6 @@ public class DocumentControllerTest {
                 .andExpect(MockMvcResultMatchers.content().json(objectMapper.writeValueAsString(new DocumentTypeDTO(documentType))));
 
         mockMvc.perform(MockMvcRequestBuilders.delete(uri + "/" + documentType.getId())
-                .content(objectMapper.writeValueAsString(documentType))
                 .contentType(MediaType.APPLICATION_JSON)
                 .headers(headers))
                 .andExpect(MockMvcResultMatchers.status().is(HttpStatus.NO_CONTENT.value()));
@@ -237,6 +236,53 @@ public class DocumentControllerTest {
         String errorMessage = exception.getMessage();
 
         mockMvc.perform(MockMvcRequestBuilders.delete(uri + "/" + documentType.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(headers))
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.NOT_FOUND.value()))
+                .andExpect(MockMvcResultMatchers.content().json(objectMapper.writeValueAsString(new ErrorDTO(errorMessage))));
+    }
+
+    @Transactional
+    @Test
+    public void shouldCreateDocumentType_ThenGetItAndReturnItWith200() throws Exception {
+        String uriString = "/documents/types";
+        URI uri = new URI(uriString);
+
+        DocumentType documentType = new DocumentType();
+        documentType.setId(++idCounter);
+        documentType.setName("CPF");
+
+        String locationUri = "http://localhost" + uriString + "/" + documentType.getId();
+
+        mockMvc.perform(MockMvcRequestBuilders.post(uri)
+                .content(objectMapper.writeValueAsString(documentType))
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(headers))
+                .andExpect(MockMvcResultMatchers.header().stringValues(HttpHeaders.LOCATION, locationUri))
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.CREATED.value()))
+                .andExpect(MockMvcResultMatchers.content().json(objectMapper.writeValueAsString(new DocumentTypeDTO(documentType))));
+
+        mockMvc.perform(MockMvcRequestBuilders.get(uri + "/" + documentType.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(headers))
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.OK.value()))
+                .andExpect(MockMvcResultMatchers.content().json(objectMapper.writeValueAsString(documentType)));
+    }
+
+    @Transactional
+    @Test
+    public void shouldTryToFindById_ThenFailWithNoSuchElementException_AndReturn404() throws Exception {
+        String uriString = "/documents/types";
+        URI uri = new URI(uriString);
+
+        DocumentType documentType = new DocumentType();
+        documentType.setId(0L);
+        documentType.setName("RG");
+
+        Exception exception = new ResourceNotFoundException(DocumentType.ENTITY_NAME);
+        String errorMessage = exception.getMessage();
+
+        mockMvc.perform(MockMvcRequestBuilders.get(uri + "/" + documentType.getId())
                 .contentType(MediaType.APPLICATION_JSON)
                 .headers(headers))
                 .andExpect(MockMvcResultMatchers.status().is(HttpStatus.NOT_FOUND.value()))

--- a/src/test/java/tech/dtech/athena/document/repository/DocumentTypeRepositoryTest.java
+++ b/src/test/java/tech/dtech/athena/document/repository/DocumentTypeRepositoryTest.java
@@ -1,6 +1,5 @@
 package tech.dtech.athena.document.repository;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,23 +24,42 @@ public class DocumentTypeRepositoryTest {
     @Autowired
     private TestEntityManager entityManager;
 
-    @BeforeEach
-    void setUp() {
+    @Test
+    void shouldFindDocumentType_GivenItsName() {
         DocumentType documentType = new DocumentType();
         documentType.setName("Hunter license");
         entityManager.persist(documentType);
+
+        DocumentType foundDocumentType = repository.findByName(documentType.getName()).orElse(null);
+
+        assertNotNull(documentType);
+        assertEquals(documentType, foundDocumentType);
     }
 
     @Test
-    void shouldFindDocumentType_GivenItsName() {
-        DocumentType documentType = repository.findByName("Hunter license").orElse(null);
+    void shouldFindDocumentType_GivenItsId() {
+        DocumentType newDocumentType = new DocumentType();
+        newDocumentType.setName("Super document type");
+        DocumentType savedDocumentType = entityManager.persist(newDocumentType);
+
+        DocumentType documentType = repository.findById(savedDocumentType.getId()).orElse(null);
 
         assertNotNull(documentType);
-        assertEquals("Hunter license", documentType.getName());
+        assertEquals(newDocumentType, documentType);
+    }
+
+    @Test
+    void shouldReturnNull_WhenSearchByNonExistentId() {
+        long someId = (long) (Math.random() + 999);
+        assertTrue(repository.findById(someId).isEmpty());
     }
 
     @Test
     void shouldNotFindDocumentType_GivenItsName_WhenNonExistant() {
+        DocumentType newDocumentType = new DocumentType();
+        newDocumentType.setName("Super document type");
+        entityManager.persist(newDocumentType);
+
         assertTrue(repository.findByName("Ninja headband").isEmpty());
     }
 
@@ -65,9 +83,11 @@ public class DocumentTypeRepositoryTest {
     @Transactional
     @Test
     void shouldDeleteDocumentType_GivenAnId() {
-        DocumentType documentType = repository.findAll().iterator().next();
-        repository.deleteById(documentType.getId());
+        DocumentType newDocumentType = new DocumentType();
+        newDocumentType.setName("Super document type");
+        DocumentType savedDocumentType = entityManager.persist(newDocumentType);
 
-        assertFalse(repository.findById(documentType.getId()).isPresent());
+        repository.deleteById(savedDocumentType.getId());
+        assertFalse(repository.findById(newDocumentType.getId()).isPresent());
     }
 }

--- a/src/test/java/tech/dtech/athena/document/service/DocumentTypeServiceTest.java
+++ b/src/test/java/tech/dtech/athena/document/service/DocumentTypeServiceTest.java
@@ -120,4 +120,25 @@ class DocumentTypeServiceTest {
         Mockito.when(repository.findById(documentType.getId())).thenReturn(Optional.of(documentType));
         assertDoesNotThrow(() -> service.delete(documentType.getId()));
     }
+
+    @Test
+    void shouldTryToFindById_ThenThrowException_WhenIdDoesNotExistOnDatasource() {
+        DocumentType documentType = new DocumentType();
+        documentType.setId(1L);
+        documentType.setName("xinxila");
+
+        Mockito.when(repository.findById(documentType.getId())).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> service.get(documentType.getId()));
+    }
+
+    @Test
+    void shouldCallRepositoryFindByIdOnce_WhenServiceGetIsCalled_ThenDoNotThrowExceptions() {
+        DocumentType documentType = new DocumentType();
+        documentType.setId(1L);
+        documentType.setName("xinxila");
+
+        Mockito.when(repository.findById(documentType.getId())).thenReturn(Optional.of(documentType));
+        assertDoesNotThrow(() -> service.get(documentType.getId()));
+    }
 }


### PR DESCRIPTION
### # What?
Add get endpoint that receives an id and returns 1 result. If result does not exist, an 404 error will be returned.

### # How?
The endpoint {BASE_URL}/documents/types/{id} was created.